### PR TITLE
refactor(stmt): optimize SQL query string extraction

### DIFF
--- a/internal/stmt/stmt_test.go
+++ b/internal/stmt/stmt_test.go
@@ -31,6 +31,8 @@ func BenchmarkQuery(b *testing.B) {
 	sqlStmt := (*sql.Stmt)(unsafe.Pointer(&s))
 
 	for i := 0; i < b.N; i++ {
-		Query(sqlStmt)
+		if Query(sqlStmt) != query {
+			b.Errorf("Query() = %q; want %q", Query(sqlStmt), query)
+		}
 	}
 }


### PR DESCRIPTION
Use reflection to safely obtain field offset at init time instead of 
hardcoded memory layout. This change:

- Uses reflect.TypeFor for type information
- Determines field offset during package initialization
- Improves safety while maintaining runtime performance
- Updates documentation to reflect new implementation

This approach is both safer and more maintainable, while keeping the 
same runtime performance characteristics.