### PR TITLE
fix: return early when WHERE clause is empty

### DIFF
--- a/node.go
+++ b/node.go
@@ -338,6 +338,9 @@ func (w WhereNode) Accept(translator driver.Translator, p Parameter) (query stri
 		return "", nil, err
 	}
 
+	if query == "" {
+		return "", args, nil
+	}
 	// A space is required at the end; otherwise, it is meaningless.
 	switch {
 	case strings.HasPrefix(query, "and ") || strings.HasPrefix(query, "AND "):


### PR DESCRIPTION
When the WHERE clause query string is empty, return immediately without
adding the "WHERE" prefix to avoid generating invalid SQL statements.

This prevents issues where empty conditions would result in a standalone
"WHERE" keyword in the final query.