### PR TITLE
perf(node): optimize TextNode string operations with builder pool

### DIFF
--- a/node.go
+++ b/node.go
@@ -187,7 +187,8 @@ func (c *TextNode) replaceHolder(query string, args []any, translator driver.Tra
 		return query, args, nil
 	}
 
-	var builder strings.Builder
+	builder := getStringBuilder()
+	defer putStringBuilder(builder)
 	builder.Grow(len(query))
 
 	lastIndex := 0
@@ -228,7 +229,8 @@ func (c *TextNode) replaceTextSubstitution(query string, p Parameter) (string, e
 		return query, nil
 	}
 
-	var builder strings.Builder
+	builder := getStringBuilder()
+	defer putStringBuilder(builder)
 	builder.Grow(len(query))
 
 	lastIndex := 0


### PR DESCRIPTION
- Use sync.Pool for strings.Builder in replaceHolder and replaceTextSubstitution
- Reuse builder objects to reduce memory allocations
- Improve memory efficiency in string manipulation operations

This change reduces memory allocations in SQL query generation by
reusing string builder objects from a pool instead of creating
new ones for each operation.