### PR TITLE
perf: optimize slice append operation

### DIFF
--- a/result_map.go
+++ b/result_map.go
@@ -121,9 +121,12 @@ func (m MultiRowsResultMap) MapTo(rv reflect.Value, rows *sql.Rows) error {
 		return err
 	}
 	target := rv.Elem()
-	// create slice with proper capacity and set the values
-	result := reflect.MakeSlice(target.Type(), 0, len(values))
-	target.Set(reflect.Append(result, values...))
+
+	// Since we've already verified the type compatibility above,
+	// we can safely grow the slice without additional type checks.
+	target.Grow(len(values))
+
+	target.Set(reflect.Append(target, values...))
 	return nil
 }
 


### PR DESCRIPTION
Improve slice append performance by pre-growing the target slice
before appending values. This eliminates the need for an intermediate
slice allocation and reduces memory operations.

- Use Grow instead of MakeSlice
- Append directly to target slice
- Reduce memory allocations