### PR TITLE
fix: prevent walk slice mutation in findFromStruct

### DIFF
--- a/result_map.go
+++ b/result_map.go
@@ -371,7 +371,7 @@ func (s *rowDestination) findFromStruct(tp reflect.Type, columns []string, colum
 		}
 		// if the field is anonymous and the type is struct, we can walk into it.
 		if deepScan := field.Anonymous && field.Type.Kind() == reflect.Struct && len(tag) == 0; deepScan {
-			s.findFromStruct(field.Type, columns, columnIndex, append(walk, i))
+			s.findFromStruct(field.Type, columns, columnIndex, append(append([]int(nil), walk...), i))
 			continue
 		}
 		// find the index of the column


### PR DESCRIPTION
Prevent potential slice mutation when recursively scanning struct fields by creating a new slice before appending index. This ensures the original walk slice remains unmodified during recursive struct traversal.