### PR TITLE
feat: add support for variadic slice unpacking syntax a(b...)

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -274,32 +274,17 @@ func evalCallExpr(exp *ast.CallExpr, params Parameter) (reflect.Value, error) {
 		return reflect.Value{}, errors.New("unsupported call expression")
 	}
 	fnType := fn.Type()
-	if numIn := fnType.NumIn(); numIn != len(exp.Args) {
-		return reflect.Value{}, fmt.Errorf("invalid number of arguments: expected %d, got %d", numIn, len(exp.Args))
+	
+	// Handle variadic arguments and slice unpacking
+	args, err := prepareCallArgs(exp, fnType, params)
+	if err != nil {
+		return reflect.Value{}, err
 	}
-	// TODO dot dot dot support
-	// ...type
+	
 	if fnType.NumOut() != 2 {
 		return reflect.Value{}, fmt.Errorf("invalid number of return values: expected 2, got %d", fn.Type().NumOut())
 	}
-	// evaluate the arguments
-	args := make([]reflect.Value, 0, len(exp.Args))
-	for i, arg := range exp.Args {
-		value, err := eval(arg, params)
-		if err != nil {
-			return reflect.Value{}, err
-		}
-		value = reflectlite.Unwrap(value)
-		// type conversion for function arguments
-		in := fnType.In(i)
-		if in.Kind() != value.Kind() {
-			if !value.CanConvert(in) {
-				return reflect.Value{}, fmt.Errorf("cannot convert %s to %s", value.Type().Name(), in.Name())
-			}
-			value = value.Convert(in)
-		}
-		args = append(args, value)
-	}
+	
 	// call the function
 	rets := fn.Call(args)
 	// unreachable code.
@@ -324,6 +309,135 @@ func evalCallExpr(exp *ast.CallExpr, params Parameter) (reflect.Value, error) {
 		return reflect.Value{}, errors.New("cannot convert return value to error")
 	}
 	return rets[0], nil
+}
+
+// prepareCallArgs prepares arguments for function call, handling variadic parameters and slice unpacking
+func prepareCallArgs(exp *ast.CallExpr, fnType reflect.Type, params Parameter) ([]reflect.Value, error) {
+	isVariadic := fnType.IsVariadic()
+	expectedArgs := fnType.NumIn()
+	
+	if !isVariadic {
+		// Regular function: exact argument count required
+		if expectedArgs != len(exp.Args) {
+			return nil, fmt.Errorf("invalid number of arguments: expected %d, got %d", expectedArgs, len(exp.Args))
+		}
+		
+		args := make([]reflect.Value, 0, len(exp.Args))
+		for i, arg := range exp.Args {
+			value, err := eval(arg, params)
+			if err != nil {
+				return nil, err
+			}
+			value = reflectlite.Unwrap(value)
+			
+			in := fnType.In(i)
+			if in.Kind() != value.Kind() {
+				if !value.CanConvert(in) {
+					return nil, fmt.Errorf("cannot convert %s to %s", value.Type().Name(), in.Name())
+				}
+				value = value.Convert(in)
+			}
+			args = append(args, value)
+		}
+		return args, nil
+	}
+	
+	// Variadic function handling
+	minArgs := expectedArgs - 1
+	if len(exp.Args) < minArgs {
+		return nil, fmt.Errorf("invalid number of arguments: expected at least %d, got %d", minArgs, len(exp.Args))
+	}
+	
+	args := make([]reflect.Value, 0, len(exp.Args))
+	
+	// Handle required arguments
+	for i := 0; i < minArgs; i++ {
+		value, err := eval(exp.Args[i], params)
+		if err != nil {
+			return nil, err
+		}
+		value = reflectlite.Unwrap(value)
+		
+		in := fnType.In(i)
+		if in.Kind() != value.Kind() {
+			if !value.CanConvert(in) {
+				return nil, fmt.Errorf("cannot convert %s to %s", value.Type().Name(), in.Name())
+			}
+			value = value.Convert(in)
+		}
+		args = append(args, value)
+	}
+	
+	// Handle variadic arguments
+	if len(exp.Args) == minArgs {
+		// No variadic arguments provided
+		return args, nil
+	}
+	
+	// Check if this is a variadic call with ellipsis
+	if exp.Ellipsis.IsValid() {
+		// Handle slice unpacking: f(a, b...)
+		if len(exp.Args) == 0 {
+			return args, nil
+		}
+		lastArg := exp.Args[len(exp.Args)-1]
+		return handleSliceUnpacking(args, lastArg, fnType, params)
+	}
+	
+	// Regular variadic arguments: f(a, b, c)
+	variadicType := fnType.In(expectedArgs - 1).Elem()
+	for i := minArgs; i < len(exp.Args); i++ {
+		value, err := eval(exp.Args[i], params)
+		if err != nil {
+			return nil, err
+		}
+		value = reflectlite.Unwrap(value)
+		
+		if value.Type().AssignableTo(variadicType) {
+			args = append(args, value)
+		} else if value.CanConvert(variadicType) {
+			args = append(args, value.Convert(variadicType))
+		} else {
+			return nil, fmt.Errorf("cannot convert %s to %s", value.Type().Name(), variadicType.Name())
+		}
+	}
+	
+	return args, nil
+}
+
+
+// handleSliceUnpacking handles slice unpacking for variadic functions
+func handleSliceUnpacking(args []reflect.Value, sliceArg ast.Expr, fnType reflect.Type, params Parameter) ([]reflect.Value, error) {
+	// Get the slice expression directly
+	sliceValue, err := eval(sliceArg, params)
+	if err != nil {
+		return nil, err
+	}
+	sliceValue = reflectlite.Unwrap(sliceValue)
+	
+	if sliceValue.Kind() != reflect.Slice && sliceValue.Kind() != reflect.Array {
+		return nil, fmt.Errorf("cannot use non-slice as variadic argument")
+	}
+	
+	variadicType := fnType.In(fnType.NumIn() - 1).Elem()
+	
+	// Unpack the slice elements
+	for i := 0; i < sliceValue.Len(); i++ {
+		elem := sliceValue.Index(i)
+		elem = reflectlite.Unwrap(elem)
+		
+		
+		if elem.Type().AssignableTo(variadicType) {
+			args = append(args, elem)
+		} else if elem.CanConvert(variadicType) {
+			converted := elem.Convert(variadicType)
+			args = append(args, converted)
+		} else {
+			return nil, fmt.Errorf("cannot convert slice element type %v to variadic type %v", elem.Type(), variadicType)
+		}
+	}
+	
+	return args, nil
 }
 
 var errInvalidSelectorExpr = errors.New("invalid selector expression")


### PR DESCRIPTION
This commit implements support for Go's slice unpacking syntax in expressions, allowing slices to be passed as variadic arguments to functions using the `...` operator.

Key changes:
- Refactored evalCallExpr to handle variadic functions and slice unpacking
- Added prepareCallArgs function to manage argument preparation
- Implemented handleSliceUnpacking for slice-to-variadic conversion
- Added comprehensive test coverage for various scenarios

Supported syntax:
- Basic slice unpacking: `sum(numbers...)`
- Mixed arguments: `sum(10, numbers[1:]...)`
- Empty slice handling: `sum([]int{}...)`
- Type safety checks for element type conversion

Testing:
- Added TestVariadicSliceUnpacking for basic functionality
- Added TestVariadicErrors for error handling
- All existing tests continue to pass

Fixes the TODO comment about dot dot dot support in eval.go