### PR TITLE
feat: add Name() method to Driver interface

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -27,6 +27,7 @@ import (
 type Driver interface {
 	// Translator returns a translator of SQL.
 	Translator() Translator
+	Name() string
 }
 
 var (

--- a/driver/mysql.go
+++ b/driver/mysql.go
@@ -24,8 +24,12 @@ func (d MySQLDriver) Translator() Translator {
 	return TranslateFunc(func(matched string) string { return "?" })
 }
 
-func (d MySQLDriver) String() string {
+func (d MySQLDriver) Name() string {
 	return "mysql"
+}
+
+func (d MySQLDriver) String() string {
+	return d.Name()
 }
 
 func init() {

--- a/driver/oracle.go
+++ b/driver/oracle.go
@@ -30,8 +30,12 @@ func (o OracleDriver) Translator() Translator {
 	})
 }
 
-func (o OracleDriver) String() string {
+func (o OracleDriver) Name() string {
 	return "oracle"
+}
+
+func (o OracleDriver) String() string {
+	return o.Name()
 }
 
 func init() {

--- a/driver/postgres.go
+++ b/driver/postgres.go
@@ -30,8 +30,12 @@ func (d PostgresDriver) Translator() Translator {
 	})
 }
 
-func (d PostgresDriver) String() string {
+func (d PostgresDriver) Name() string {
 	return "postgres"
+}
+
+func (d PostgresDriver) String() string {
+	return d.Name()
 }
 
 func init() {

--- a/driver/sqlite.go
+++ b/driver/sqlite.go
@@ -24,8 +24,12 @@ func (d SQLiteDriver) Translator() Translator {
 	return TranslateFunc(func(matched string) string { return "?" })
 }
 
-func (d SQLiteDriver) String() string {
+func (d SQLiteDriver) Name() string {
 	return "sqlite3"
+}
+
+func (d SQLiteDriver) String() string {
+	return d.Name()
 }
 
 func init() {


### PR DESCRIPTION
- Add Name() string method to Driver interface for standardized driver naming
- Refactor all driver implementations (MySQL, Oracle, PostgreSQL, SQLite) to implement Name() method
- Maintain backward compatibility by keeping String() method that delegates to Name()
- Improve interface consistency and make driver name retrieval more explicit

Breaking change: Driver interface now requires Name() method implementation