### PR TITLE
fix: preserve original SQL formatting by removing TrimSpace

### DIFF
--- a/node.go
+++ b/node.go
@@ -145,7 +145,7 @@ func (g NodeGroup) Accept(translator driver.Translator, p Parameter) (query stri
 		return "", nil, nil
 	}
 
-	return strings.TrimSpace(builder.String()), args, nil
+	return builder.String(), args, nil
 }
 
 // pureTextNode is a node of pure text.


### PR DESCRIPTION
Remove strings.TrimSpace() from NodeGroup.Accept method to maintain the original indentation, line breaks, and whitespace formatting from XML-defined SQL templates.

This ensures that the generated SQL output retains the readable formatting structure as defined in the source XML, improving debugging and log readability.

Fixes: SQL formatting being stripped despite proper parsing